### PR TITLE
Optimize model formulae

### DIFF
--- a/src/jit_kernels/simulation.cu
+++ b/src/jit_kernels/simulation.cu
@@ -11,13 +11,13 @@ __device__ int select_flip_bit(int state_size, const float* __restrict__ transit
 {
 	float r = curand_uniform(rand) * total_rate;
 	float sum = 0;
+	int idx = 0;
 	for (int i = 0; i < state_size; i++)
 	{
 		sum += transition_rates[i];
-		if (r < sum)
-			return i;
+		idx += (sum <= r) ? 1 : 0;
 	}
-	return state_size - 1;
+	return idx;
 }
 
 extern "C" __global__ void initialize_random(int trajectories_count, unsigned long long seed,

--- a/src/parser/expressions.cpp
+++ b/src/parser/expressions.cpp
@@ -201,7 +201,7 @@ void identifier_expression::generate_code(const driver& drv, const std::string&,
 	int i = it - drv.nodes.begin();
 	int word = i / 32;
 	int bit = i % 32;
-	os << "((state[" << word << "] & " << (1u << bit) << "u) != 0)";
+	os << "(state[" << word << "] & " << (1u << bit) << "u)";
 }
 
 variable_expression::variable_expression(std::string name) : name(std::move(name)) {}

--- a/src/parser/expressions.cpp
+++ b/src/parser/expressions.cpp
@@ -106,12 +106,12 @@ void binary_expression::generate_code(const driver& drv, const std::string& curr
 			break;
 		case operation::AND:
 			left->generate_code(drv, current_node, os);
-			os << " && ";
+			os << " & ";
 			right->generate_code(drv, current_node, os);
 			break;
 		case operation::OR:
 			left->generate_code(drv, current_node, os);
-			os << " || ";
+			os << " | ";
 			right->generate_code(drv, current_node, os);
 			break;
 		case operation::EQ:
@@ -201,7 +201,7 @@ void identifier_expression::generate_code(const driver& drv, const std::string&,
 	int i = it - drv.nodes.begin();
 	int word = i / 32;
 	int bit = i % 32;
-	os << "(state[" << word << "] & " << (1u << bit) << "u)";
+	os << "((state[" << word << "] & " << (1u << bit) << "u) != 0)";
 }
 
 variable_expression::variable_expression(std::string name) : name(std::move(name)) {}

--- a/src/parser/expressions.h
+++ b/src/parser/expressions.h
@@ -41,7 +41,6 @@ public:
 	float evaluate(const driver& drv) const override;
 	void generate_code(const driver& drv, const std::string& current_node, std::ostream& os) const override;
 
-protected:
 	operation op;
 	expr_ptr expr;
 };
@@ -53,7 +52,6 @@ public:
 	float evaluate(const driver& drv) const override;
 	void generate_code(const driver& drv, const std::string& current_node, std::ostream& os) const override;
 
-protected:
 	operation op;
 	expr_ptr left;
 	expr_ptr right;
@@ -66,7 +64,6 @@ public:
 	float evaluate(const driver& drv) const override;
 	void generate_code(const driver& drv, const std::string& current_node, std::ostream& os) const override;
 
-protected:
 	expr_ptr left;
 	expr_ptr middle;
 	expr_ptr right;
@@ -79,7 +76,6 @@ public:
 	float evaluate(const driver& drv) const override;
 	void generate_code(const driver& drv, const std::string& current_node, std::ostream& os) const override;
 
-protected:
 	expr_ptr expr;
 };
 
@@ -90,7 +86,6 @@ public:
 	float evaluate(const driver& drv) const override;
 	void generate_code(const driver& drv, const std::string& current_node, std::ostream& os) const override;
 
-protected:
 	float value;
 };
 
@@ -101,7 +96,6 @@ public:
 	float evaluate(const driver& drv) const override;
 	void generate_code(const driver& drv, const std::string& current_node, std::ostream& os) const override;
 
-protected:
 	std::string name;
 };
 
@@ -112,7 +106,6 @@ public:
 	float evaluate(const driver& drv) const override;
 	void generate_code(const driver& drv, const std::string& current_node, std::ostream& os) const override;
 
-protected:
 	std::string name;
 };
 
@@ -123,6 +116,5 @@ public:
 	float evaluate(const driver& drv) const override;
 	void generate_code(const driver& drv, const std::string& current_node, std::ostream& os) const override;
 
-protected:
 	std::string name;
 };


### PR DESCRIPTION
The typical formula has the form of:
```
if (is_this_node_set)
    return @logic ? 0 : sth;
else
    return @logic ? sth : 0;
```
In this addition, we optimize the code generation of these formulae to generate (a possibly complex) `@logic` only once and make use of neat ternary operators to reduce thread divergence.