### PR TITLE
optimize window_average_small by adding shared mem

### DIFF
--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -217,7 +217,7 @@ void generator::generate_non_internal_index(std::ostringstream& os) const
 	{
 		if (!drv_.nodes[i].is_internal(drv_))
 		{
-			os << "((state[" << i / 32 << "] & (1u << " << i % 32 << ")) >> " << (i % 32) - non_internals++ << ")";
+			os << "((state[" << i / 32 << "] & " << (1u << i % 32) << "u) >> " << (i % 32) - non_internals++ << ")";
 			if (non_internals != non_internals_count)
 			{
 				os << " | ";

--- a/src/jit_kernels/simulation.cu
+++ b/src/jit_kernels/simulation.cu
@@ -119,7 +119,12 @@ __device__ void simulate_inner(int trajectories_count, int state_size, int traje
 		else
 		{
 			if (discrete_time)
+			{
 				time += time_tick;
+				// due to a common rounding error for discrete simulations,
+				// we set time to max_time explicitely if it is close enough to max_time
+				time = max_time - time_tick < time ? max_time : time;
+			}
 			else
 				time += -logf(curand_uniform(&rand)) / total_rate;
 

--- a/src/jit_kernels/window_average_small.cu
+++ b/src/jit_kernels/window_average_small.cu
@@ -4,68 +4,133 @@ using uint32_t = unsigned int;
 
 extern __device__ uint32_t get_non_internal_index(const state_word_t* __restrict__ state);
 
+__device__ void clear_shared(float* shared, int shared_size)
+{
+	for (int i = threadIdx.x; i < shared_size; i += blockDim.x)
+	{
+		shared[i] = 0.f;
+	}
+}
+
+__device__ void clear_shared(float* shared, int shared_size_float, int shared_size_int)
+{
+	for (int i = threadIdx.x; i < shared_size_float; i += blockDim.x)
+	{
+		shared[i] = 0.f;
+	}
+
+	int* shared_probs = reinterpret_cast<int*>(shared + shared_size_float);
+
+	for (int i = threadIdx.x; i < shared_size_int; i += blockDim.x)
+	{
+		shared_probs[i] = 0;
+	}
+}
+
+template <typename T>
+__device__ void store_shared(int windows_count, uint32_t noninternal_states_count, bool extended_shared,
+							 float* __restrict__ shared, T* __restrict__ window_probs,
+							 float* __restrict__ window_tr_entropies)
+{
+	for (int i = threadIdx.x; i < windows_count; i += blockDim.x)
+	{
+		atomicAdd(window_tr_entropies + i, shared[i]);
+	}
+
+	if (extended_shared)
+	{
+		T* shared_probs = reinterpret_cast<T*>(shared + windows_count);
+		for (int i = threadIdx.x; i < windows_count * noninternal_states_count; i += blockDim.x)
+		{
+			atomicAdd(window_probs + i, shared_probs[i]);
+		}
+	}
+}
+
 extern "C" __global__ void window_average_small(int max_traj_len, int n_trajectories, int state_words,
-												uint32_t noninternal_states_count, float time_tick,
-												const state_word_t* __restrict__ traj_states,
+												uint32_t noninternal_states_count, float time_tick, int windows_count,
+												bool use_shared_for_probs, const state_word_t* __restrict__ traj_states,
 												const float* __restrict__ traj_times,
 												const float* __restrict__ traj_tr_entropies,
 												float* __restrict__ window_probs,
 												float* __restrict__ window_tr_entropies)
 {
-	auto id = blockIdx.x * blockDim.x + threadIdx.x;
+	extern __shared__ float shared[];
 
-	if (id >= n_trajectories * max_traj_len)
-		return;
+	clear_shared(shared, windows_count + (use_shared_for_probs ? windows_count * noninternal_states_count : 0));
 
-	if (id % max_traj_len == 0 || traj_times[id] == 0.f)
+	__syncthreads();
+
+	int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+	int id = tid + tid / (max_traj_len - 1) + 1;
+
+	if (!(tid >= n_trajectories * (max_traj_len - 1) || traj_times[id] == 0.f))
 	{
-		return;
+		const auto state_idx = get_non_internal_index(traj_states + id * state_words);
+		const float tr_h = traj_tr_entropies[id];
+
+		float slice_begin = traj_times[id - 1];
+		float slice_end = traj_times[id];
+		int wnd_idx = floorf(slice_begin / time_tick);
+
+		while (slice_end > slice_begin)
+		{
+			float wnd_end = (wnd_idx + 1) * time_tick;
+			float slice_in_wnd = fminf(slice_end, wnd_end) - slice_begin;
+
+			if (use_shared_for_probs)
+				atomicAdd_block((shared + windows_count) + (wnd_idx * noninternal_states_count + state_idx),
+								slice_in_wnd);
+			else
+				atomicAdd(window_probs + (wnd_idx * noninternal_states_count + state_idx), slice_in_wnd);
+			atomicAdd_block(shared + wnd_idx, tr_h * slice_in_wnd);
+
+			wnd_idx++;
+
+			slice_begin = fminf(slice_end, wnd_end);
+		}
 	}
 
-	const auto state_idx = get_non_internal_index(traj_states + id * state_words);
-	const float tr_h = traj_tr_entropies[id];
+	__syncthreads();
 
-	float slice_begin = traj_times[id - 1];
-	float slice_end = traj_times[id];
-	int wnd_idx = floorf(slice_begin / time_tick);
-
-	while (slice_end > slice_begin)
-	{
-		float wnd_end = (wnd_idx + 1) * time_tick;
-		float slice_in_wnd = fminf(slice_end, wnd_end) - slice_begin;
-
-		atomicAdd(window_probs + (wnd_idx * noninternal_states_count + state_idx), slice_in_wnd);
-		atomicAdd(window_tr_entropies + wnd_idx, tr_h * slice_in_wnd);
-
-		wnd_idx++;
-
-		slice_begin = fminf(slice_end, wnd_end);
-	}
+	store_shared(windows_count, noninternal_states_count, use_shared_for_probs, shared, window_probs,
+				 window_tr_entropies);
 }
 
-extern "C" __global__ void window_average_small_discrete(int max_traj_len, int n_trajectories, int state_words,
-														 uint32_t noninternal_states_count, float time_tick,
-														 const state_word_t* __restrict__ traj_states,
-														 const float* __restrict__ traj_times,
-														 const float* __restrict__ traj_tr_entropies,
-														 int* __restrict__ window_probs,
-														 float* __restrict__ window_tr_entropies)
+extern "C" __global__ void window_average_small_discrete(
+	int max_traj_len, int n_trajectories, int state_words, uint32_t noninternal_states_count, float time_tick,
+	int windows_count, bool use_shared_for_probs, const state_word_t* __restrict__ traj_states,
+	const float* __restrict__ traj_times, const float* __restrict__ traj_tr_entropies, int* __restrict__ window_probs,
+	float* __restrict__ window_tr_entropies)
 {
-	auto id = blockIdx.x * blockDim.x + threadIdx.x;
+	extern __shared__ float shared[];
+	int* window_probs_shared = reinterpret_cast<int*>(shared + windows_count);
 
-	if (id >= n_trajectories * max_traj_len)
-		return;
+	clear_shared(shared, windows_count, (use_shared_for_probs ? windows_count * noninternal_states_count : 0));
 
-	if (id % max_traj_len == 0 || traj_times[id] == 0.f)
+	__syncthreads();
+
+	int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+	int id = tid + tid / (max_traj_len - 1) + 1;
+
+	if (!(tid >= n_trajectories * (max_traj_len - 1) || traj_times[id] == 0.f))
 	{
-		return;
+		const auto state_idx = get_non_internal_index(traj_states + id * state_words);
+		const float tr_h = traj_tr_entropies[id];
+
+		int wnd_idx = lroundf(traj_times[id - 1] / time_tick);
+
+		if (use_shared_for_probs)
+			atomicAdd_block(window_probs_shared + (wnd_idx * noninternal_states_count + state_idx), 1);
+		else
+			atomicAdd(window_probs + (wnd_idx * noninternal_states_count + state_idx), 1);
+		atomicAdd_block(shared + wnd_idx, tr_h);
 	}
 
-	const auto state_idx = get_non_internal_index(traj_states + id * state_words);
-	const float tr_h = traj_tr_entropies[id];
+	__syncthreads();
 
-	int wnd_idx = lroundf(traj_times[id - 1] / time_tick);
-
-	atomicAdd(window_probs + (wnd_idx * noninternal_states_count + state_idx), 1);
-	atomicAdd(window_tr_entropies + wnd_idx, tr_h);
+	store_shared(windows_count, noninternal_states_count, use_shared_for_probs, shared, window_probs,
+				 window_tr_entropies);
 }

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -13,4 +13,12 @@ struct kernel_wrapper
 		CU_CHECK(cuLaunchKernel(kernel, grid_size.x, grid_size.y, grid_size.z, block_size.x, block_size.y, block_size.z,
 								0, 0, void_args, 0));
 	}
+
+	template <typename... Args>
+	void run_shared(dim3 grid_size, dim3 block_size, int shared_bytes, Args... args)
+	{
+		void* void_args[sizeof...(Args)] = { &args... };
+		CU_CHECK(cuLaunchKernel(kernel, grid_size.x, grid_size.y, grid_size.z, block_size.x, block_size.y, block_size.z,
+								shared_bytes, 0, void_args, 0));
+	}
 };


### PR DESCRIPTION
`window_average_small` is the second longest-running kernel after the simulate kernel.
This commit optimizes it by caching the intermediate results in the shared memory.